### PR TITLE
Add static, reproducable last.fm charts

### DIFF
--- a/auto/lastfm.q
+++ b/auto/lastfm.q
@@ -1,14 +1,16 @@
 \d .lfm
 
-tm:{
+postChart:{[s;e]                                                                                / [start timestamp;end timestamp] post chart for given range
   .lg.o"Running last.fm charts timer";
   if[not .lfm.valid[];:.lg.w"last.fm not enabled, chart timer aborted"];                        / exit if functionality disabled
   if[0=count .lfm.users;:.lg.w"No last.fm usernames provuded, chart timer aborted"];            / exit if no cached usernames
   if[0=count .lfm.o.charts;:.lg.w"No charts currently specified in .lfm.o.charts"];
-  c:chart[];                                                                                    / get charts
+  c:chart[.z.d-7;.z.d];                                                                         / get charts
   .lg.o"Posting last.fm charts to slack as lastfmbot in ",.lfm.channel;
   .slack.postase[c;.slack.chanlist .lfm.channel;"lastfmbot";":lastfm:"];                        / post charts as lastfmbot
  };
+
+tm:{postChart[.z.d-7;.z.d]};                                                                    / post chart for previous 7 days
 
 \d .
 

--- a/auto/lastfm.q
+++ b/auto/lastfm.q
@@ -10,7 +10,7 @@ postChart:{[s;e]                                                                
   .slack.postase[c;.slack.chanlist .lfm.channel;"lastfmbot";":lastfm:"];                        / post charts as lastfmbot
  };
 
-tm:{postChart[.z.d-7;.z.d]};                                                                    / post chart for previous 7 days
+tm:{postChart .(.z.d-7 0)+10:00};                                                               / post chart for previous 7 days
 
 \d .
 

--- a/auto/lastfm.q
+++ b/auto/lastfm.q
@@ -5,7 +5,7 @@ postChart:{[s;e]                                                                
   if[not .lfm.valid[];:.lg.w"last.fm not enabled, chart timer aborted"];                        / exit if functionality disabled
   if[0=count .lfm.users;:.lg.w"No last.fm usernames provuded, chart timer aborted"];            / exit if no cached usernames
   if[0=count .lfm.o.charts;:.lg.w"No charts currently specified in .lfm.o.charts"];
-  c:chart[.z.d-7;.z.d];                                                                         / get charts
+  c:chart[s;e];                                                                                 / get charts
   .lg.o"Posting last.fm charts to slack as lastfmbot in ",.lfm.channel;
   .slack.postase[c;.slack.chanlist .lfm.channel;"lastfmbot";":lastfm:"];                        / post charts as lastfmbot
  };

--- a/util/lastfm.q
+++ b/util/lastfm.q
@@ -50,7 +50,7 @@
 .lfm.r.recent:{[u;s;e].lfm.req.p`method`user`limit`from`to!(`user.getrecenttracks;u;0W),.lfm.unix s,e}; / [username;start timestamp;end timestamp] get scrobbled tracks in specified window
 
 .lfm.user.recent:{[u;s;e]                                                                       / [user;start timsetamp;end timestamp]
-  res:flip[.lfm.req.cols[`recent]!()],(cl:.lfm.req.cols`recent)#/:.lfm.r.recent[u;s;e];         / request top artists
+  res:flip[cl!()],(cl:.lfm.req.cols`recent)#/:.lfm.r.recent[u;s;e];                             / request top artists
   :`artist`track`album xcol@[;`name;`$].lfm.parse[res;cols res];                                / extract data from nested columns
  };
 
@@ -107,7 +107,7 @@
  };
 
 / helper functions to correctly parse columns
-.lfm.parse:{[t;c]{.lfm.p[y]x}/[t;c]};                                                            / [table;columns] format columns
+.lfm.parse:{[t;c]{.lfm.p[y]x}/[t;c]};                                                           / [table;columns] format columns
 .lfm.p.artist:{@[x;`artist;{`$x`$"#text"}@']};                                                  / extract name from nested table
 .lfm.p.album:{@[x;`album;{`$x`$"#text"}@']};                                                    / extract name from nested table
 
@@ -128,7 +128,7 @@
     .lg.e"Failed to get user info for ",u," with error: ",v`message;
     :(0b;"username is invalid");                                                                / return failed status
   ];
-  `.lfm.users upsert(`$id;`$n;`$u);                                                             / add/update record in cache
+  `.lfm.users upsert`$(id;n;u);                                                                 / add/update record in cache
   :(1b;"successfully added username ",u);                                                       / return passed status
  };
 


### PR DESCRIPTION
Previously the charts were created from `getTop` requests from the last fm API which always run backwords in time from the current timestamp. This unfortunately creates the scenario where a produced chart is really a moment in time event. By moving to use `getRecentTracks` instead the start and end points for which to retrieve scrobbles can be specified and therefore can be repeated quite easily. From this raw data we can readily aggregate to produce all 3 chart types as required.

A secondary advantage to this approach is that less API requests need to be made as most users listen to under 1000 tracks per week, which is the limit for a page returned from the API.

The chart timer has been updated to collect chart data over the period Monday 10am -> Monday 10am.