### PR TITLE
Split Last FM charts into separate messages

### DIFF
--- a/auto/lastfm.q
+++ b/auto/lastfm.q
@@ -7,7 +7,7 @@ postChart:{[s;e]                                                                
   if[0=count .lfm.o.charts;:.lg.w"No charts currently specified in .lfm.o.charts"];
   c:chart[s;e];                                                                                 / get charts
   .lg.o"Posting last.fm charts to slack as lastfmbot in ",.lfm.channel;
-  .slack.postase[c;.slack.chanlist .lfm.channel;"lastfmbot";":lastfm:"];                        / post charts as lastfmbot
+  .slack.postase[;.slack.chanlist .lfm.channel;"lastfmbot";":lastfm:"]each value c;             / post charts as lastfmbot
  };
 
 tm:{postChart .(.z.d-7 0)+10:00};                                                               / post chart for previous 7 days

--- a/util/lastfm.q
+++ b/util/lastfm.q
@@ -75,12 +75,13 @@
 
 .lfm.c.wrapper:{[t;data]                                                                        / [type;data] wrapper for selecting chart data
   c:.lfm.o.default^.lfm.o.custom t;                                                             / find number of results to return
-  res:`n xcols 0!update n:1+i from c sublist`scrobbles xdesc .lfm.c[t]data;                     / sort by scrobbles and add numbering
+  res:c sublist`scrobbles xdesc .lfm.c[t]data;                                                  / sort by scrobbles
+  res:`n xcols 0!update n:fills?[differ scrobbles;1+i;0N]from res;                              / number track placement
   .lg.o"Returning ",string[t]," chart";
   :where[not .lfm.o.cols]_res;                                                                  / return chart, applying optional column settings
  };
 
-.lfm.c.format:{[t;data]t," Chart\n\n",.fmt.t .lfm.h.trim data};                               / [type;data] format chart for slack
+.lfm.c.format:{[t;data]t," Chart\n\n",.fmt.t .lfm.h.trim data};                                 / [type;data] format chart for slack
 
 .lfm.h.trim:{[data]                                                                             / [data] trim columns
   d:(cols[data]inter key d)#d:`artist`track`album!30 50 40;                                     / custom column widths
@@ -97,13 +98,13 @@
   ];
   data:.lfm.scrobbles[s;e];                                                                     / get scrobbles for all users
   .lg.o"Producing charts for ",", "sv string .lfm.o.charts;
-  fm:.lfm.o.format[data]'[(),.lfm.o.charts];                                                    / get top charts for passed params
-  res:"\n\n"sv fm;                                                                              / get top charts for passed params and stitch together
+  fm:.lfm.o.charts!.lfm.o.format[data]'[(),.lfm.o.charts];                                      / get top charts for passed params
   uc:"\n\nUser count: ",string count .lfm.users;                                                / get user stats
   us:"\nUnique scrobblers: ",string exec count distinct user from data;                         / get number of users to scrobble over charting period
   sc:"\nScrobble count: ",string count data;                                                    / get total scrobbles
-  .lg.o"Returning formatted charts";
-  :"```",res,uc,us,sc,"```";                                                                    / wrap in code block to preserve formatting in slack
+  fm[`stats]:uc,us,sc;                                                                          / add stats to dictionary
+  .lg.o"Returning formatted charts and stats";
+  :{"```",x,"```"}each fm;                                                                      / wrap in code block to preserve formatting in slack
  };
 
 / helper functions to correctly parse columns

--- a/util/lastfm.q
+++ b/util/lastfm.q
@@ -75,7 +75,7 @@
 
 .lfm.c.wrapper:{[t;data]                                                                        / [type;data] wrapper for selecting chart data
   c:.lfm.o.default^.lfm.o.custom t;                                                             / find number of results to return
-  res:c sublist`scrobbles xdesc .lfm.c[t]data;                                                  / sort by scrobbles
+  res:c sublist`scrobbles`usercount xdesc .lfm.c[t]data;                                        / sort by scrobbles and total listening users
   res:`n xcols 0!update n:fills?[differ scrobbles;1+i;0N]from res;                              / number track placement
   .lg.o"Returning ",string[t]," chart";
   :where[not .lfm.o.cols]_res;                                                                  / return chart, applying optional column settings

--- a/util/lastfm.q
+++ b/util/lastfm.q
@@ -35,7 +35,7 @@
     r:.lfm.req.r d;                                                                             / make request
     if[`error in key r;
       .lg.e"Error making last.fm request, error code ",string r`error;
-      if[r[`error]in 8 29f;                                                                     / if backend fails (8) or rate limited exceeded (29) then sleep and retry
+      if[r[`error]in 8 29f;                                                                     / if backend fails (8) or rate limit exceeded (29) then sleep and retry
         .lg.o"Sleeping for 60s before retrying";
         system"sleep 60";
         :(t;d;l);


### PR DESCRIPTION
Seems about half the time charts are published we do not get correct formatting as they are spread over multiple messages. The changes here post each chart and the stats as separate messages so hopefully that eliminates this issue going forward.