### PR TITLE
Save symbol columns as strings to ensure lastfm output can be read correctly

### DIFF
--- a/util/lastfm.q
+++ b/util/lastfm.q
@@ -120,7 +120,7 @@
   if[not .lfm.o.outputChart;.lg.o"Saving to disk is disabled";:()];                             / exit early if saving not enabled
   .lg.o"Saving ",string[t]," chart to disk";
   fn:`$("_"sv enlist[string t],@'[;8;:;"_"](16 sublist/:string(s;e))except\:".:"),".csv";       / create filename for current chart
-  (fp:` sv .lfm.o.output,fn)0:","0: c;                                                          / save chart to disk
+  (fp:` sv .lfm.o.output,fn)0:","0:@[c;exec c from meta[c]where t="s";string];                  / save chart to disk, converting symbols to string to preserve commas
   .lg.o"Finished saving ",string[t]," chart to ",1_string fp;
  };
 


### PR DESCRIPTION
One line change the will ensure fields are wrapped in quotes to ensure fields can be read back correctly if they contain commas.