### PR TITLE
Handle user change events to better maintain userlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ When starting kdbslack, include `command` in the load directories to load these 
 
 Event plugins respond to [events](#https://api.slack.com/events-api) from Slack e.g. a new team member joining Slack.
 
-Currently the only example implemented of this is for a team member joining, the `team_join` event. This example is currently located in `util/slack.q` although in future this will be moved to it's own directory similar to auto & command.
+Currently there are two examples of this is; first is for a team member joining, the `team_join` event. This example is currently located in `events/team_join.q`. Second is for a `user_change` event, which is currently located in `events/user_change.q`.
 
 An event handler function should accept a dictionary, similar to a command handler. In order to register a handler function, it should be placed in the `.slack.events` dictionary, for example:
 

--- a/command/lastfm.q
+++ b/command/lastfm.q
@@ -6,7 +6,7 @@ adduser:{[x]
     :.slack.ret"functionality not enabled";                                                     / return status message privately
   ];
   r:exec from .slack.userlist where id like x`user_id;                                          / get details for current user
-  .lg.o"Updating last.fm username for ",r[`real_name]," (",r[`name],")";
+  .lg.o"Updating last.fm username for ",string[r`real_name]," (",string[r`name],")";
   st:.lfm.u.handler[x`user_id;r`real_name;trim x`text];                                         / update last.fm username for user
   :.slack.ret st 1;                                                                             / return status message privately
  };

--- a/command/lastfm.q
+++ b/command/lastfm.q
@@ -1,7 +1,7 @@
 \d .lfm
 
 adduser:{[x]
-  if[not .lfm.valid[];                                                                          / check if funtionality is enabled
+  if[not .lfm.valid[];                                                                          / check if functionality is enabled
     .lg.w"last.fm not enabled, user request cannot be made";
     :.slack.ret"functionality not enabled";                                                     / return status message privately
   ];

--- a/command/lastfm.q
+++ b/command/lastfm.q
@@ -1,12 +1,13 @@
 \d .lfm
 
-adduser:{
-  if[not .lfm.valid[];                                                                          / check if cuntionality is enabled
+adduser:{[x]
+  if[not .lfm.valid[];                                                                          / check if funtionality is enabled
     .lg.w"last.fm not enabled, user request cannot be made";
-    :.slack.ret"functionality not enabled";                                                      / return status message privately
+    :.slack.ret"functionality not enabled";                                                     / return status message privately
   ];
-  p:.j.k[.slack.users.info x`user_id][`user;`profile];                                          / get user profile
-  st:.lfm.u.handler[x`user_id;p`real_name;trim x`text];                                         / update last.fm username for user
+  r:exec from .slack.userlist where id like x`user_id;                                          / get details for current user
+  .lg.o"Updating last.fm username for ",r[`real_name]," (",r[`name],")";
+  st:.lfm.u.handler[x`user_id;r`real_name;trim x`text];                                         / update last.fm username for user
   :.slack.ret st 1;                                                                             / return status message privately
  };
 

--- a/events/user_change.q
+++ b/events/user_change.q
@@ -1,0 +1,13 @@
+\d .slack
+
+events.user_change:{[e]
+  if[e[`user]`deleted;                                                              //check if user has been deleted
+     .lg.o"Removing user ",e[`user][`real_name]," (",e[`user][`name],")";
+     :delete from .slack.userlist where id like e[`user]`id;                        //remove deleted user from user list
+    ];
+  .lg.o"Updating user ",e[`user][`real_name]," (",e[`user][`name],")";
+  .slack.userlist,:"*SS"$`id`name`real_name#e`user;                                 //add updated details to user list
+  .slack.userlist:select from .slack.userlist where i=(max;i)fby id;                //remove duplicate entries
+ }
+
+\d .slack

--- a/events/user_change.q
+++ b/events/user_change.q
@@ -5,9 +5,11 @@ events.user_change:{[e]
      .lg.o"Removing user ",e[`user][`real_name]," (",e[`user][`name],")";
      :delete from .slack.userlist where id like e[`user]`id;                        //remove deleted user from user list
     ];
-  .lg.o"Updating user ",e[`user][`real_name]," (",e[`user][`name],")";
-  .slack.userlist,:"*SS"$`id`name`real_name#e`user;                                 //add updated details to user list
-  .slack.userlist:select from .slack.userlist where i=(max;i)fby id;                //remove duplicate entries
+  if[all`real_name`name`id in key e`user;
+     .lg.o"Updating user ",e[`user][`real_name]," (",e[`user][`name],")";
+     .slack.userlist,:"*SS"$`id`name`real_name#e`user;                              //add updated details to user list
+     .slack.userlist:select from .slack.userlist where i=(max;i)fby id;             //remove duplicate entries
+    ];
  }
 
 \d .slack

--- a/util/lastfm.q
+++ b/util/lastfm.q
@@ -11,7 +11,7 @@
 .lfm.o.charts:`tracks`artists`albums;                                                           / list of charts to return
 .lfm.o.cols:`users`usercount!01b;                                                               / optional columns to include in output
 .lfm.o.outputChart:1b;                                                                          / determine if chart output should be saved to disk
-.lfm.o.output:`:/home/shared/lastfm;                                                            / directory to save chart output
+.lfm.o.output:hsym@[get;`.lfm.o.output;`:/home/shared/lastfm];                                  / directory to save chart output
 
 / preamble
 .lfm.key:@[{first read0 x};.lfm.file.key;""];                                                   / get api key
@@ -109,7 +109,8 @@
   data:.lfm.scrobbles[s;e];                                                                     / get scrobbles for all users
   .lg.o"Producing charts for ",", "sv string .lfm.o.charts;
   fm:.lfm.o.charts!.lfm.o.format[s;e;data]'[(),.lfm.o.charts];                                  / get top charts for passed params
-  uc:"\n\nUser count: ",string count .lfm.users;                                                / get user stats
+  u:`$exec id from .slack.userlist;                                                             / get list of user ids from slack
+  uc:"\n\nUser count: ",string count select from .lfm.users where uid in u;                     / get user stats
   us:"\nUnique scrobblers: ",string exec count distinct user from data;                         / get number of users to scrobble over charting period
   sc:"\nScrobble count: ",string count data;                                                    / get total scrobbles
   fm[`stats]:uc,us,sc;                                                                          / add stats to dictionary

--- a/util/lastfm.q
+++ b/util/lastfm.q
@@ -70,7 +70,8 @@
 
 .lfm.scrobbles:{[s;e]                                                                           / [start timestamp;end timestamp] get scrobbles for all users
   .lg.o"Requesting scrobbles for each user between ",string[s]," and ",string e;
-  res:raze .lfm.h.scrobbles[s;e]./:exec(name,'username)from .lfm.users;                         / get top chart for passed param for each user
+  u:`$exec id from .slack.userlist;                                                             / get list of user ids from slack
+  res:raze .lfm.h.scrobbles[s;e]./:exec(name,'username)from .lfm.users where uid in u;          / get top chart for passed param for each valid user
   .lg.o"Returning top scrobbles for each user between ",string[s]," and ",string e;
   :res;                                                                                         / return raw data
  };
@@ -137,17 +138,17 @@
  };
 
 .lfm.u.add:{[id;n;u]                                                                            / [id;name;username] add user to cache
-  .lg.o"Updating username for ",n;
+  .lg.o"Updating last.fm username for ",n;
   if[(`$u)in exec username from .lfm.users;                                                     / check for username duplication
     .lg.w"User ",n," is attempting to add username ",u," that is already in use";
     :(0b;"username already in use");                                                            / return failed status
   ];
   if[`error in key v:.lfm.req.s`method`user!("user.getinfo";u);                                 / verify that valid last.fm username has been passed
-    .lg.e"Failed to get user info for ",u," with error: ",v`message;
+    .lg.e"Failed to get last.fm user info for ",u," with error: ",v`message;
     :(0b;"username is invalid");                                                                / return failed status
   ];
   `.lfm.users upsert`$(id;n;u);                                                                 / add/update record in cache
-  :(1b;"successfully added username ",u);                                                       / return passed status
+  :(1b;"successfully added last.fm username ",u);                                               / return passed status
  };
 
 .lfm.u.rm:{[id;n;u]                                                                             / [id;name;username] remove user from cache

--- a/util/lastfm.q
+++ b/util/lastfm.q
@@ -7,8 +7,8 @@
 .lfm.channel:"qradio";                                                                          / channel to post charts to
 .lfm.url:"http://ws.audioscrobbler.com/2.0/?";                                                  / base of URL
 .lfm.o.default:10;                                                                              / default number to include for charts
-.lfm.o.custom:`tracks`artists`albums!20 20 10;                                                  / custom number of results to include for each chart type
-.lfm.o.charts:`tracks`artists`albums;                                                           / list of charts to return
+.lfm.o.custom:`tracks`artists`albums`stats!20 20 10 20;                                         / custom number of results to include for each chart type
+.lfm.o.charts:`tracks`artists`albums`stats;                                                     / list of charts to return
 .lfm.o.cols:`users`usercount!01b;                                                               / optional columns to include in output
 .lfm.o.outputChart:1b;                                                                          / determine if chart output should be saved to disk
 .lfm.o.output:hsym@[get;`.lfm.o.output;`:/home/shared/lastfm];                                  / directory to save chart output
@@ -82,13 +82,29 @@
 .lfm.c.artists:{[data]select scrobbles:count i,users:distinct user,usercount:count distinct user by artist from data}; / select data for artists chart
 
 .lfm.c.wrapper:{[s;e;t;data]                                                                    / [start timestamp;end timestamp;type;data] wrapper for selecting chart data
-  c:.lfm.o.default^.lfm.o.custom t;                                                             / find number of results to return
+  f:$[t in 1_key .lfm.s;t;`default];                                                            / determine aggregation funtion, allowing for custom logic
+  cht:(.lfm.s f)[s;e;t;data];                                                                   / aggregate data
+  .lfm.save[s;e;t;cht];                                                                         / save chart to disk (if enabled)
+  .lg.o"Returning ",string[t]," chart";
+  :(.lfm.o.default^.lfm.o.custom t)sublist cht;                                                 / return chart
+ };
+
+.lfm.s.default:{[s;e;t;data]
   res:`scrobbles`usercount xdesc .lfm.c[t]data;                                                 / sort by scrobbles and total listening users
   res:`n xcols 0!update n:fills?[differ scrobbles;1+i;0N]from res;                              / number track placement
-  .lg.o"Returning ",string[t]," chart";
-  cht:where[not .lfm.o.cols]_res;                                                               / apply optional column settings
-  .lfm.save[s;e;t;cht];                                                                         / save chart to disk (if enabled)
-  :c sublist cht;                                                                               / return chart
+  :where[not .lfm.o.cols]_res;                                                                  / apply optional column settings
+ };
+
+.lfm.s.stats:{[s;e;t;data]                                                                      / [start timestamp;end timestamp;data] generate statistics from raw chart data
+  u:`$exec id from .slack.userlist;                                                             / get list of user ids from slack
+  sts:([]stat:();size:());
+  sts,:(`$"Registered users";count .lfm.users);                                                 / count number of valid users
+  sts,:(`$"Valid users";count select from .lfm.users where uid in u);                           / count number of valid users
+  sts,:(`$"Unique scrobblers";count distinct data`user);                                        / get number of users to scrobble over charting period
+  sts,:(`Scrobbles;count data);                                                                 / get total scrobbles over period
+  sts,:(`Artists;count distinct data`artist);                                                   / get total scrobbles over period
+  sts,:(`Albums;count distinct data`album);                                                     / get total scrobbles over period
+  :sts;                                                                                         / return stats
  };
 
 .lfm.c.format:{[t;data]t," Chart\n\n",.fmt.t .lfm.h.trim data};                                 / [type;data] format chart for slack
@@ -108,13 +124,8 @@
   ];
   data:.lfm.scrobbles[s;e];                                                                     / get scrobbles for all users
   .lg.o"Producing charts for ",", "sv string .lfm.o.charts;
-  fm:.lfm.o.charts!.lfm.o.format[s;e;data]'[(),.lfm.o.charts];                                  / get top charts for passed params
-  u:`$exec id from .slack.userlist;                                                             / get list of user ids from slack
-  uc:"\n\nUser count: ",string count select from .lfm.users where uid in u;                     / get user stats
-  us:"\nUnique scrobblers: ",string exec count distinct user from data;                         / get number of users to scrobble over charting period
-  sc:"\nScrobble count: ",string count data;                                                    / get total scrobbles
-  fm[`stats]:uc,us,sc;                                                                          / add stats to dictionary
-  .lg.o"Returning formatted charts and stats";
+  fm:.lfm.o.charts!.lfm.o.format[s;e;data]'[.lfm.o.charts];                                     / get top charts for passed params
+  .lg.o"Returning formatted charts and tables";
   :{"```",x,"```"}each fm;                                                                      / wrap in code block to preserve formatting in slack
  };
 

--- a/util/slack.q
+++ b/util/slack.q
@@ -45,6 +45,11 @@ getchannelid:{[x]
   :(n;m@n);                                                                         //return closest named channel & it's ID
  }
 
+getusers:{
+  r:((k:`id`name`real_name),`deleted)#/:.j.k[.slack.users.list[]]`members;          //get list of all users currently signed up
+  :"*SS"$/:k#select from r where not deleted;                                       //remove users that have been deleted
+ }
+
 postas0:{[m;c;u;i;e] /m-message,c-channel ID,u-user,i-icon,e-emoji
   d:()!();                                                                          //create dictionary to build up API request
   d[`token]:token;
@@ -61,6 +66,6 @@ postas:postas0[;;;"";""]                                                        
 postasi:postas0[;;;;""]                                                             //projection to post as username with icon URL
 postase:postas0[;;;"";]                                                             //projection to post as username with emoji icon
 
-userlist:"*SS"$/:`id`name`real_name#/:.j.k[.slack.users.list[]]`members;            //get list of all users currently signed up
+userlist:getusers[];                                                                //get list of all valid users
 chanlist:{c:.j.k[channels.list[]]`channels;g:.j.k[groups.list[]]`groups;exec name!id from raze `name`id#/:(c;g)}[]
 \d .


### PR DESCRIPTION
In its current form `.slack.userlist` can contain users that have been deleted. Changes made in this PR should better handle changes to user data.

- when creating `.slack.userlist` deleted users are filtered out.
- `user_change` events are handled. If deleted the user is removed, else an attempt is made to update their details.
- last.fm charts are only generated from users that aren't deleted (cache is left be to prevent it being deleted).

There has been limited testing for these changes as I do not have an API token and the API docs don't make it entirely clear what info is contained in a `user_change` event.

Some open questions:
- Is `.slack.userlist` definitely complete? Does the request for this data involve pagination?
- Should `.slack.userlist` be keyed by id? This value should be unique
- Should `.slack.userlist` be expanded to included deleted and start/end date if available?